### PR TITLE
fix bug caused by linux kernel

### DIFF
--- a/capture/network.go
+++ b/capture/network.go
@@ -78,6 +78,7 @@ func initEthernetHandlerFromPacpgo() (handler *pcapgo.EthernetHandle) {
 	return
 }
 
+// in online use, we found a strange bug: pcap cost 100% core CPU and memory increase along
 func initEthernetHandlerFromPacp() (handler *pcap.Handle) {
 	handler, err := pcap.OpenLive(DeviceName, 65536, false, pcap.BlockForever)
 	if err != nil {
@@ -101,7 +102,7 @@ func (nc *networkCard) Listen() (receiver chan model.QueryPiece) {
 func (nc *networkCard) listenNormal() {
 	go func() {
 		aliveCounter := 0
-		handler := initEthernetHandlerFromPacp()
+		handler := initEthernetHandlerFromPacpgo()
 
 		for {
 			var data []byte

--- a/capture/network.go
+++ b/capture/network.go
@@ -128,8 +128,8 @@ func (nc *networkCard) listenNormal() {
 				continue
 			}
 
-			// packet := gopacket.NewPacket(data, layers.LayerTypeEthernet, gopacket.NoCopy)
-			packet := gopacket.NewPacket(data, handler.LinkType(), gopacket.NoCopy)
+			packet := gopacket.NewPacket(data, layers.LayerTypeEthernet, gopacket.NoCopy)
+			// packet := gopacket.NewPacket(data, handler.LinkType(), gopacket.NoCopy)
 			m := packet.Metadata()
 			m.CaptureInfo = ci
 


### PR DESCRIPTION
线上运行过程中偶尔会遇到一个核占满，内存使用率一直增长的情况
![Screenshot from 2019-12-05 20-10-12](https://user-images.githubusercontent.com/26314914/70234314-5912de80-179b-11ea-97c7-91a84354012b.png)

经过排查问题是该问题引发 https://github.com/the-tcpdump-group/libpcap/issues/546
此PR解决了该问题
   