### PR TITLE
Kafka compress support

### DIFF
--- a/exporter/kafka.go
+++ b/exporter/kafka.go
@@ -54,7 +54,7 @@ func checkParams()  {
 	case "lz4":
 		compressType = sarama.CompressionLZ4
 	default:
-		panic(fmt.Sprintf("cannot support compress type: %s", compress))
+		panic(fmt.Sprintf("cannot support kafka compress type: %s", compress))
 	}
 
 	fmt.Printf("kafka message compress type: %s", compress)


### PR DESCRIPTION
支持压缩kafka消息，支持的压缩类型有：gzip, snappy, lz4